### PR TITLE
Fix unit tests

### DIFF
--- a/README
+++ b/README
@@ -15,7 +15,7 @@ copyright: "(c) 2005-2006 Chris Wanstrath, 2006-2011 Vlad Andersen"
 tested on: [php 5.2.x]
 
 installation: >
-  Copy spyc.php to a directory you can
+  Copy Spyc.php to a directory you can
   access with your YAML-ready PHP script.
 
   That's it!
@@ -69,7 +69,7 @@ meat and a few potatoes:
       $yaml will become an array of all the data in wicked.yaml
     code: |
 
-      include('spyc.php');
+      include('Spyc.php');
 
       $yaml = Spyc::YAMLLoad('wicked.yaml');
 
@@ -79,7 +79,7 @@ meat and a few potatoes:
         array('A YAML','document in a','string')
     code: |
 
-      include('spyc.php');
+      include('Spyc.php');
 
       $yaml  = '- A YAML\n- document in a\n- string.';
       $array = Spyc::YAMLLoad($yaml);
@@ -90,7 +90,7 @@ meat and a few potatoes:
       $array.
     code: |
 
-      include('spyc.php');
+      include('Spyc.php');
 
       $array['name']  = 'chris';
       $array['sport'] = 'curbing';

--- a/Spyc.php
+++ b/Spyc.php
@@ -1032,14 +1032,14 @@ class Spyc {
 }
 
 // Enable use of Spyc from command line
-// The syntax is the following: php spyc.php spyc.yaml
+// The syntax is the following: php Spyc.php spyc.yaml
 
 define ('SPYC_FROM_COMMAND_LINE', false);
 
 do {
   if (!SPYC_FROM_COMMAND_LINE) break;
   if (empty ($_SERVER['argc']) || $_SERVER['argc'] < 2) break;
-  if (empty ($_SERVER['PHP_SELF']) || $_SERVER['PHP_SELF'] != 'spyc.php') break;
+  if (empty ($_SERVER['PHP_SELF']) || $_SERVER['PHP_SELF'] != 'Spyc.php') break;
   $file = $argv[1];
   printf ("Spyc loading file: %s\n", $file);
   print_r (spyc_load_file ($file));

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "php": ">=5.3.1"
     },
     "autoload": {
-        "files": [ "spyc.php" ]
+        "files": [ "Spyc.php" ]
     }
 }

--- a/examples/yaml-dump.php
+++ b/examples/yaml-dump.php
@@ -9,7 +9,7 @@
 # learn some basic YAML.
 #
 
-include('../spyc.php');
+include('../Spyc.php');
 
 $array[] = 'Sequence item';
 $array['The Key'] = 'Mapped value';

--- a/examples/yaml-load.php
+++ b/examples/yaml-load.php
@@ -7,7 +7,7 @@
 # license: [MIT License, http://www.opensource.org/licenses/mit-license.php]
 #
 
-include('../spyc.php');
+include('../Spyc.php');
 
 $array = Spyc::YAMLLoad('../spyc.yaml');
 

--- a/tests/DumpTest.php
+++ b/tests/DumpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once ("../spyc.php");
+require_once ("../Spyc.php");
 
 class DumpTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/IndentTest.php
+++ b/tests/IndentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once ("../spyc.php");
+require_once ("../Spyc.php");
 
 class IndentTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once 'PHPUnit/Framework.php';
-require_once ("../spyc.php");
+require_once ("../Spyc.php");
 
 class ParseTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/RoundTripTest.php
+++ b/tests/RoundTripTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once ("../spyc.php");
+require_once ("../Spyc.php");
 
 function roundTrip($a) { return Spyc::YAMLLoad(Spyc::YAMLDump(array('x' => $a))); }
 


### PR DESCRIPTION
I tried to run the unit tests and I got an error about spyc.php being not found.
The file is named with a capital s, probably because i'm on linux but requiring case-sensitive solved the issue.
