### PR TITLE
Fixed broken examples.

### DIFF
--- a/examples/yaml-dump.php
+++ b/examples/yaml-dump.php
@@ -9,7 +9,7 @@
 # learn some basic YAML.
 #
 
-include('../spyc.php');
+include('../Spyc.php');
 
 $array[] = 'Sequence item';
 $array['The Key'] = 'Mapped value';

--- a/examples/yaml-load.php
+++ b/examples/yaml-load.php
@@ -7,7 +7,7 @@
 # license: [MIT License, http://www.opensource.org/licenses/mit-license.php]
 #
 
-include('../spyc.php');
+include('../Spyc.php');
 
 $array = Spyc::YAMLLoad('../spyc.yaml');
 


### PR DESCRIPTION
The renaming of Spyc.php (from "spyc.php") broke the includes on the examples. This fixes it.
