### PR TITLE
Parsing breaks when using an inline array of strings without spaces

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -651,7 +651,8 @@ class Spyc {
 
     } while (strpos ($inline, '[') !== false || strpos ($inline, '{') !== false);
 
-    $explode = explode(', ',$inline);
+    $explode = explode(',',$inline);
+    $explode = array_map('trim', $explode);
     $stringi = 0; $i = 0;
 
     while (1) {

--- a/spyc.yaml
+++ b/spyc.yaml
@@ -198,6 +198,9 @@ noindent_records:
 "a:2":
   - 2000
 
+array with commas:
+  ["0","1"]
+
 # [Endloop]
 endloop: |
   Does this line in the end indeed make Spyc go to an infinite loop?

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -231,6 +231,10 @@ class ParseTest extends PHPUnit_Framework_TestCase {
       $this->assertEquals (array (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19), $this->yaml['array on several lines']);
     }
 
+    public function testArrayWithCommas() {
+      $this->assertEquals(array (0, 1), $this->yaml['array with commas']);
+    }
+
     public function testmoreLessKey() {
       $this->assertEquals ('<value>', $this->yaml['morelesskey']);
     }


### PR DESCRIPTION
ie. the following breaks:

```
test: ["1","2"]
```

and returns an array with string `"1","2"`. Was expecting the same result as (note the space between elements):

```
test: ["1", "2"]
```
