### PR TITLE
Allow user to use your official repository with Composer

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@
 #
 --- %YAML:1.1
 title: Spyc -- a Simple PHP YAML Class
-version: 0.5
+version: 0.5.1
 authors: [chris wanstrath (chris@ozmm.org), vlad andersen (vlad.andersen@gmail.com)]
 websites: [http://www.yaml.org, http://spyc.sourceforge.net]
 license: [MIT License, http://www.opensource.org/licenses/mit-license.php]

--- a/Spyc.php
+++ b/Spyc.php
@@ -1,7 +1,7 @@
 <?php
 /**
    * Spyc -- A Simple PHP YAML Class
-   * @version 0.5
+   * @version 0.5.1
    * @author Vlad Andersen <vlad.andersen@gmail.com>
    * @author Chris Wanstrath <chris@ozmm.org>
    * @link http://code.google.com/p/spyc/

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
     "autoload": {
         "files": [ "Spyc.php" ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.5.x-dev"
+        }
     }
 }


### PR DESCRIPTION
In order to be known by Composer, you must register your package on the [Composer repository](https://packagist.org/packages/submit).

This allow users to use your official and up-to-date repository instead of forks.
