### PR TITLE
Preserve data type of numeric strings

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -382,6 +382,8 @@ class Spyc {
     } else {
       if ($this->setting_dump_force_quotes && is_string ($value) && $value !== self::REMPTY)
         $value = '"' . $value . '"';
+      if (is_numeric($value) && is_string($value))
+        $value = '"' . $value . '"';
     }
 
 

--- a/tests/DumpTest.php
+++ b/tests/DumpTest.php
@@ -75,7 +75,7 @@ class DumpTest extends PHPUnit_Framework_TestCase {
 
     public function testDumpNumerics() {
       $dump = Spyc::YAMLDump(array ('404', '405', '500'));
-      $awaiting = "---\n- 404\n- 405\n- 500\n";
+      $awaiting = "---\n- \"404\"\n- \"405\"\n- \"500\"\n";
       $this->assertEquals ($awaiting, $dump);
     }
 

--- a/tests/RoundTripTest.php
+++ b/tests/RoundTripTest.php
@@ -42,6 +42,23 @@ class RoundTripTest extends PHPUnit_Framework_TestCase {
       $this->assertEquals (array ('x' => array ("#color" => '#fff')), roundTrip (array ("#color" => '#fff')));
     }
 
+    public function testPreserveString() {
+      $result1 = roundTrip ('0');
+      $result2 = roundTrip ('true');
+      $this->assertTrue (is_string ($result1['x']));
+      $this->assertTrue (is_string ($result2['x']));
+    }
+
+    public function testPreserveBool() {
+      $result = roundTrip (true);
+      $this->assertTrue (is_bool ($result['x']));
+    }
+
+    public function testPreserveInteger() {
+      $result = roundTrip (0);
+      $this->assertTrue (is_int ($result['x']));
+    }
+
     public function testWordWrap() {
       $this->assertEquals (array ('x' => "aaaaaaaaaaaaaaaaaaaaaaaaaaaa  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), roundTrip ("aaaaaaaaaaaaaaaaaaaaaaaaaaaa  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
     }


### PR DESCRIPTION
This patch will help prevent string to integer conversion.

Here is an example script:

```
<?php
require 'Spyc.php';
$x = "x: '0'\n";
$data = Spyc::YAMLLoad($x);
var_dump($data['x']);
$data = Spyc::YAMLLoad(Spyc::YAMLDump($data));
var_dump($data['x']);
```

Result from current implementation:

```
string(1) "0"
int(0)
```

Patched implementation:

```
string(1) "0"
string(1) "0"
```
