### PR TITLE
Improved PHP_SELF check for CLI

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -1036,7 +1036,7 @@ class Spyc {
 do {
   if (PHP_SAPI != 'cli') break;
   if (empty ($_SERVER['argc']) || $_SERVER['argc'] < 2) break;
-  if (empty ($_SERVER['PHP_SELF']) || $_SERVER['PHP_SELF'] != 'Spyc.php') break;
+  if (empty ($_SERVER['PHP_SELF']) || FALSE === strpos ($_SERVER['PHP_SELF'], 'Spyc.php') ) break;
   $file = $argv[1];
   echo json_encode (spyc_load_file ($file));
 } while (0);


### PR DESCRIPTION
Improved PHP_SELF check, this should make it work in case the file is stored in a different directory; e.g. bin/Spyc.php
