### PR TITLE
Convert quoted \n characters to new lines.

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -545,13 +545,13 @@ class Spyc {
       $is_quoted = true;
     } while (0);
 
-    if ($is_quoted)
+    if ($is_quoted) {
+      $value = str_replace('\n', "\n", $value);
       return strtr(substr ($value, 1, -1), array ('\\"' => '"', '\'\'' => '\'', '\\\'' => '\''));
+    }
 
     if (strpos($value, ' #') !== false && !$is_quoted)
       $value = preg_replace('/\s+#(.+)$/','',$value);
-
-    if (!$is_quoted) $value = str_replace('\n', "\n", $value);
 
     if ($first_character == '[' && $last_character == ']') {
       // Take out strings sequences and mappings

--- a/spyc.yaml
+++ b/spyc.yaml
@@ -26,6 +26,7 @@ Float: 5.34
 Negative: -90
 SmallFloat: 0.7
 NewLine: \n
+QuotedNewLine: "\n"
 
 # A sequence
 - PHP Class
@@ -115,6 +116,9 @@ all languages:
 
 # Added in .2.4: bug [ 1418193 ] Quote Values in Nested Arrays
 - [a, ['1', "2"], b]
+
+# Add in .5.2: Quoted new line values.
+- "First line\nSecond line\nThird line"
 
 # Added in .2.4: malformed YAML
 all

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -76,9 +76,12 @@ class ParseTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testNewline() {
-      $this->assertSame ("\n", $this->yaml['NewLine']);
+      $this->assertSame ('\n', $this->yaml['NewLine']);
     }
 
+    public function testQuotedNewline() {
+      $this->assertSame ("\n", $this->yaml['QuotedNewLine']);
+    }
 
     public function testSeq0() {
       $this->assertEquals ("PHP Class", $this->yaml[0]);
@@ -189,6 +192,10 @@ class ParseTest extends PHPUnit_Framework_TestCase {
 
     public function testShortSequence() {
       $this->assertEquals (array( 0 => "a", 1 => array (0 => 1, 1 => 2), 2 => "b"), $this->yaml[16]);
+    }
+
+    public function testQuotedNewlines() {
+      $this->assertEquals ("First line\nSecond line\nThird line", $this->yaml[17]);
     }
 
     public function testHash_1() {


### PR DESCRIPTION
Fixes https://github.com/mustangostang/spyc/issues/27, quoted `"\n"` characters should be converted to new lines when parsing. Likewise, unquoted `\n` characters should _not_ be converted to new lines.
