### PR TITLE
Compatibility fixes

### DIFF
--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -358,14 +358,15 @@ dog', $this->yaml['many_lines']);
       $this->assertEquals ($Expected, $Actual['bar']);
     }
 
+    // Plain characters http://www.yaml.org/spec/1.2/spec.html#id2789510
     public function testKai() {
-      $Expected = array (array ('example' => 'value'));
+      $Expected = array('-example' => 'value');
       $Actual = spyc_load_file ('indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['kai']);
     }
 
     public function testKaiList() {
-      $Expected = array ('-item', '-item', 'item');
+      $Expected = array ('-item', '-item', '-item');
       $Actual = spyc_load_file ('indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['kai_list_of_items']);
     }
@@ -380,4 +381,9 @@ dog', $this->yaml['many_lines']);
       $this->assertSame ($expected, $this->yaml['quotes']);
     }
 
+    // Separation spaces http://www.yaml.org/spec/1.2/spec.html#id2778394
+    public function testMultipleArrays() {
+      $expected = array(array(array('x')));
+      $this->assertSame($expected, Spyc::YAMLLoad("- - - x"));
+    }
 }


### PR DESCRIPTION
I originally started this branch to experiment with some things related to #26 (opened earlier today). Spyc now reads things as one would expect (I think - give it a go and let me know what you think).

Please feel free to leave this open for a bit - no rush at all, more soliciting feedback than anything else.

It is getting a bit difficult to decide what things we should/shouldn't support in Spyc, since it does not implement any version of the YAML spec verbatim. As such, I did not remove any of the previously accepted translators like "y" or "n" for boolean values (these are not mentioned in the YAML 1.2 spec). I did, however, remove plus "+" and minus "-" for true and false values, since I couldn't find them anywhere in the YAML spec, and the minus "-" was interfering with the separations spaces implementations.

Compatibility fixes:
- Spaces are required for separation on list items, ex: '- -blah' == array('-blah')
- Separation spaces are respected, ex: '- - - x' == array(array(array('x')))
- 'Null' keyword is accepted in addition to 'NULL' and 'null'

This commit also includes a bit of refactoring to make things a bit more effecient
and respect the DRY principle a bit more.
