### PR TITLE
Spyc.php fails to account for negative PHP_INT_MAX

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -654,7 +654,7 @@ class Spyc {
 
     if ( is_numeric($value) && preg_match ('/^(-|)[1-9]+[0-9]*$/', $value) ){
       $intvalue = (int)$value;
-      if ($intvalue != PHP_INT_MAX)
+      if ($intvalue != PHP_INT_MAX && $intvalue != ~PHP_INT_MAX)
         $value = $intvalue;
       return $value;
     }


### PR DESCRIPTION
While detecting the int type, spyc properly checks if the numerical value exceeds PHP_INT_MAX. However, it fails to account for the negative limit, so numbers less than (for example) the 64-bit limit of `-9223372036854775808` get clobbered into the limit.