### PR TITLE
Check if Spyc class exists before including

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -43,6 +43,8 @@ if (!function_exists('spyc_dump')) {
   }
 }
 
+if (!class_exists('Spyc')) {
+
 /**
    * The Simple PHP YAML Class.
    *
@@ -1133,6 +1135,7 @@ class Spyc {
     $line = trim(str_replace($group, '', $line));
     return $line;
   }
+}
 }
 
 // Enable use of Spyc from command line


### PR DESCRIPTION
I'm having an issue where Spyc is bundled with the WP-CLI phar as well as being used in a plugin. The way it's currently configured, Spyc is getting included twice, because it's using Composer's files autoloading. Adding a `class_exists` check would fix that problem for me.