### PR TITLE
Replaced all double underscores in methods with single underscore to …

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -121,7 +121,7 @@ class Spyc {
  * @return array
  */
   public function load ($input) {
-    return $this->__loadString($input);
+    return $this->_loadString($input);
   }
 
  /**
@@ -130,7 +130,7 @@ class Spyc {
  * @return array
  */
   public function loadFile ($file) {
-    return $this->__load($file);
+    return $this->_load($file);
   }
 
   /**
@@ -150,7 +150,7 @@ class Spyc {
      */
   public static function YAMLLoad($input) {
     $Spyc = new Spyc;
-    return $Spyc->__load($input);
+    return $Spyc->_load($input);
   }
 
   /**
@@ -174,7 +174,7 @@ class Spyc {
      */
   public static function YAMLLoadString($input) {
     $Spyc = new Spyc;
-    return $Spyc->__loadString($input);
+    return $Spyc->_loadString($input);
   }
 
   /**
@@ -471,12 +471,12 @@ class Spyc {
 
 // LOADING FUNCTIONS
 
-  private function __load($input) {
+  private function _load($input) {
     $Source = $this->loadFromSource($input);
     return $this->loadWithSource($Source);
   }
 
-  private function __loadString($input) {
+  private function _loadString($input) {
     $Source = $this->loadFromString($input);
     return $this->loadWithSource($Source);
   }


### PR DESCRIPTION
…prevent warning in PHP7. Please refer to issue #58.