### PR TITLE
Hex support on php 7.0

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -672,7 +672,7 @@ class Spyc {
       return $value;
     }
 
-    if (is_numeric($value) && preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
+    if ( is_string($value) && preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
       // Hexadecimal value.
       return hexdec($value);
     }


### PR DESCRIPTION
As of `7.0.0	Strings in hexadecimal (e.g. 0xf4c3b00c) notation are no longer regarded as numeric strings, i.e. is_numeric() returns FALSE now.`

therefore we can't rely on is_numeric.