### PR TITLE
Get tests running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
+composer.lock
 .DS_Store

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="all">
+            <directory suffix="Test.php">tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/DumpTest.php
+++ b/tests/DumpTest.php
@@ -1,13 +1,11 @@
 <?php
 
-require_once ("../Spyc.php");
-
 class DumpTest extends PHPUnit_Framework_TestCase {
 
     private $files_to_test = array();
 
     public function setUp() {
-      $this->files_to_test = array ('../spyc.yaml', 'failing1.yaml', 'indent_1.yaml', 'quotes.yaml');
+      $this->files_to_test = array (__DIR__.'/../spyc.yaml', 'failing1.yaml', 'indent_1.yaml', 'quotes.yaml');
     }
 
     public function testShortSyntax() {

--- a/tests/IndentTest.php
+++ b/tests/IndentTest.php
@@ -1,13 +1,11 @@
 <?php
 
-require_once ("../Spyc.php");
-
 class IndentTest extends PHPUnit_Framework_TestCase {
 
     protected $Y;
 
     protected function setUp() {
-        $this->Y = Spyc::YAMLLoad("indent_1.yaml");
+        $this->Y = Spyc::YAMLLoad(__DIR__."/indent_1.yaml");
     }
 
     public function testIndent_1() {

--- a/tests/LoadTest.php
+++ b/tests/LoadTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once ("../Spyc.php");
-
 class LoadTest extends PHPUnit_Framework_TestCase {
     public function testQuotes() {
         $test_values = array(

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -1,13 +1,11 @@
 <?php
 
-require_once ("../Spyc.php");
-
 class ParseTest extends PHPUnit_Framework_TestCase {
 
     protected $yaml;
 
     protected function setUp() {
-      $this->yaml = spyc_load_file('../spyc.yaml');
+      $this->yaml = spyc_load_file(__DIR__.'/../spyc.yaml');
     }
 
     public function testMergeHashKeys() {
@@ -15,19 +13,19 @@ class ParseTest extends PHPUnit_Framework_TestCase {
         array ('step' => array('instrument' => 'Lasik 2000', 'pulseEnergy' => 5.4, 'pulseDuration' => 12, 'repetition' => 1000, 'spotSize' => '1mm')),
         array ('step' => array('instrument' => 'Lasik 2000', 'pulseEnergy' => 5.4, 'pulseDuration' => 12, 'repetition' => 1000, 'spotSize' => '2mm')),
       );
-      $Actual = spyc_load_file ('indent_1.yaml');
+      $Actual = spyc_load_file (__DIR__.'/indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['steps']);
     }
 
     public function testDeathMasks() {
       $Expected = array ('sad' => 2, 'magnificent' => 4);
-      $Actual = spyc_load_file ('indent_1.yaml');
+      $Actual = spyc_load_file (__DIR__.'/indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['death masks are']);
     }
 
     public function testDevDb() {
       $Expected = array ('adapter' => 'mysql', 'host' => 'localhost', 'database' => 'rails_dev');
-      $Actual = spyc_load_file ('indent_1.yaml');
+      $Actual = spyc_load_file (__DIR__.'/indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['development']);
     }
 
@@ -341,45 +339,45 @@ dog', $this->yaml['many_lines']);
     }
 
     public function testAngleQuotes() {
-      $Quotes = Spyc::YAMLLoad('quotes.yaml');
+      $Quotes = Spyc::YAMLLoad(__DIR__.'/quotes.yaml');
       $this->assertEquals (array ('html_tags' => array ('<br>', '<p>'), 'html_content' => array ('<p>hello world</p>', 'hello<br>world'), 'text_content' => array ('hello world')),
           $Quotes);
     }
 
     public function testFailingColons() {
-      $Failing = Spyc::YAMLLoad('failing1.yaml');
+      $Failing = Spyc::YAMLLoad(__DIR__.'/failing1.yaml');
       $this->assertSame (array ('MyObject' => array ('Prop1' => array ('key1:val1'))),
           $Failing);
     }
 
     public function testQuotesWithComments() {
       $Expected = 'bar';
-      $Actual = spyc_load_file ('comments.yaml');
+      $Actual = spyc_load_file (__DIR__.'/comments.yaml');
       $this->assertEquals ($Expected, $Actual['foo']);
     }
 
     public function testArrayWithComments() {
       $Expected = array ('x', 'y', 'z');
-      $Actual = spyc_load_file ('comments.yaml');
+      $Actual = spyc_load_file (__DIR__.'/comments.yaml');
       $this->assertEquals ($Expected, $Actual['arr']);
     }
 
     public function testAfterArrayWithKittens() {
       $Expected = 'kittens';
-      $Actual = spyc_load_file ('comments.yaml');
+      $Actual = spyc_load_file (__DIR__.'/comments.yaml');
       $this->assertEquals ($Expected, $Actual['bar']);
     }
 
     // Plain characters http://www.yaml.org/spec/1.2/spec.html#id2789510
     public function testKai() {
       $Expected = array('-example' => 'value');
-      $Actual = spyc_load_file ('indent_1.yaml');
+      $Actual = spyc_load_file (__DIR__.'/indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['kai']);
     }
 
     public function testKaiList() {
       $Expected = array ('-item', '-item', '-item');
-      $Actual = spyc_load_file ('indent_1.yaml');
+      $Actual = spyc_load_file (__DIR__.'/indent_1.yaml');
       $this->assertEquals ($Expected, $Actual['kai_list_of_items']);
     }
 

--- a/tests/RoundTripTest.php
+++ b/tests/RoundTripTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once ("../Spyc.php");
-
 function roundTrip($a) { return Spyc::YAMLLoad(Spyc::YAMLDump(array('x' => $a))); }
 
 


### PR DESCRIPTION
Tests can now be run using `composer install` and then `./vendor/bin/phpunit`.

Before this, the only way I could work out how to run the tests was to drop a PHPUnit phar file in the tests directory.

There are still a few failing tests, although these were already failing and need to be addressed separately.