### PR TITLE
Added feature to convert {} into empty object using stdClass()

### DIFF
--- a/Spyc.php
+++ b/Spyc.php
@@ -88,6 +88,12 @@ class Spyc {
    */
   public $setting_use_syck_is_possible = false;
 
+  /**
+   * Setting this to true will forse YAMLLoad to use syck_load function when
+   * possible. False by default.
+   * @var bool
+   */
+  public $setting_empty_hash_as_object = false;
 
 
   /**#@+
@@ -147,9 +153,15 @@ class Spyc {
      * @access public
      * @return array
      * @param string $input Path of YAML file or string containing YAML
+     * @param array set options
      */
-  public static function YAMLLoad($input) {
+  public static function YAMLLoad($input, $options = []) {
     $Spyc = new Spyc;
+    foreach ($options as $key => $value) {
+        if (property_exists($Spyc, $key)) {
+            $Spyc->$key = $value;
+        }
+    }
     return $Spyc->_load($input);
   }
 
@@ -171,9 +183,15 @@ class Spyc {
      * @access public
      * @return array
      * @param string $input String containing YAML
+     * @param array set options
      */
-  public static function YAMLLoadString($input) {
+  public static function YAMLLoadString($input, $options = []) {
     $Spyc = new Spyc;
+    foreach ($options as $key => $value) {
+        if (property_exists($Spyc, $key)) {
+            $Spyc->$key = $value;
+        }
+    }
     return $Spyc->_loadString($input);
   }
 
@@ -574,18 +592,19 @@ class Spyc {
       $line = $this->stripGroup ($line, $group);
     }
 
-    if ($this->startsMappedSequence($line))
+    if ($this->startsMappedSequence($line)) {
       return $this->returnMappedSequence($line);
+    }
 
-    if ($this->startsMappedValue($line))
+    if ($this->startsMappedValue($line)) {
       return $this->returnMappedValue($line);
+    }
 
     if ($this->isArrayElement($line))
-     return $this->returnArrayElement($line);
+      return $this->returnArrayElement($line);
 
     if ($this->isPlainArray($line))
      return $this->returnPlainArray($line);
-
 
     return $this->returnKeyValuePair($line);
 
@@ -599,6 +618,11 @@ class Spyc {
      */
   private function _toType($value) {
     if ($value === '') return "";
+
+    if ($this->setting_empty_hash_as_object && $value === '{}') {
+      return new stdClass();
+    }
+
     $first_character = $value[0];
     $last_character = substr($value, -1, 1);
 
@@ -1101,6 +1125,7 @@ class Spyc {
       }
       // Set the type of the value.  Int, string, etc
       $value = $this->_toType($value);
+
       if ($key === '0') $key = '__!YAMLZero';
       $array[$key] = $value;
     } else {

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -396,4 +396,18 @@ dog', $this->yaml['many_lines']);
       $expected = array(array(array('x')));
       $this->assertSame($expected, Spyc::YAMLLoad("- - - x"));
     }
+
+    public function testElementWithEmptyHash()
+    {
+        $element = "hash: {}\narray: []";
+        $yaml = Spyc::YAMLLoadString($element);
+        $this->assertEquals($yaml['hash'], []);
+        $this->assertEquals($yaml['array'], []);
+
+        $yaml = Spyc::YAMLLoadString($element, [
+            'setting_empty_hash_as_object' => true
+        ]);
+        $this->assertInstanceOf(stdClass::class, $yaml['hash']);
+        $this->assertEquals($yaml['array'], []);
+    }
 }


### PR DESCRIPTION
Added the conversion of an empty YAML hash `{}` into an empty object using `new stdClass()`. This is needed if you want to differentiate an empty array `[]` from an empty hash `{}`. At the moment the two items are converted into array. I need this feature in order to convert a YAML file into a JSON, and I have empty objects (`{}`). A possible way to accomplish this is to use an empty `stdClass()` value, as discussed [here](https://stackoverflow.com/questions/8595627/best-way-to-create-an-empty-object-in-json-with-php).

I added a public option `Spyc ::setting_empty_hash_as_object` to enable or disable this feature (`false` by default).

I changed the static functions `YAMLLoad` and `YAMLLoadString` to allow an optional parameter, as follows:
```php
public static function YAMLLoadString($input, $options = []);
public static function YAMLLoad($input, $options = []);
```
This can facilitate the settings of the Sync properties.
With this PR now you can set this option (also `setting_dump_force_quotes` and `setting_use_syck_is_possible`) as follows:
```php
$string = 'test: {}';
$yaml = Spyc::YAMLLoadString($string, [
     'setting_empty_hash_as_object' => true
]);
var_dump($yaml);
/*
array(1) {
  ["test"]=>
  object(stdClass)#2 (0) {
  }
}
*/
```
I also provided a `ParseTest::testElementWithEmptyHash` unit test.